### PR TITLE
Dish menu database integration

### DIFF
--- a/triton-eats/server/src/Menu/menu-database.ts
+++ b/triton-eats/server/src/Menu/menu-database.ts
@@ -1,0 +1,76 @@
+import { db } from "../firebaseConfig";
+import { doc, getDoc, setDoc, updateDoc, collection, getCountFromServer, where, query, getDocs } from "firebase/firestore";
+import { dishItem } from "../Menu/types";
+
+export const findDish = async (dish_name: string) => {
+    const docRef = doc(db, "dishes", dish_name);
+    const docSnap = await getDoc(docRef);
+
+    if (docSnap.exists()) {
+        return docSnap.data();
+    } else {
+        throw new Error("No such dish!");
+    }
+}
+
+export const updateDishDB = async (updatedDish: dishItem) => {
+    const dishRef = doc(db, "dishes", updatedDish.food_name);
+    await updateDoc(dishRef, updatedDish);
+};
+
+export const getId = async () => {
+
+    const collectionRef = collection(db, "dishes");
+    const snapshot = await getCountFromServer(collectionRef);
+    return snapshot.data().count;
+
+}
+
+export const getIdByName = async (newDish: dishItem) => {
+
+    const dish_name = newDish.food_name;
+    
+    const collectionRef = collection(db, "dishes");
+    // find the document with the right name property
+    const q = query(collectionRef, where("food_name", "==", dish_name));
+    const snapshot = await getDocs(q);
+    
+    if(snapshot.size === 0) {
+        return (await getId()).toString();
+    } else {
+        for(const doc of snapshot.docs) {
+            if(doc.data().dining_hall) {
+                return doc.id.toString();
+            }
+        }
+        return (await getId()).toString();
+    }
+    
+}
+
+export const addDishToDB = async (newDish: dishItem) => {
+
+    const dish_id = await getIdByName(newDish);
+    newDish.food_id = dish_id;
+    console.log("Adding dish with id:", dish_id);
+    const dishRef = doc(db, "dishes", dish_id);
+
+    if((await getDoc(dishRef)).exists()) {
+        console.log("Dish already exists!");
+        await updateDoc(dishRef, newDish);
+    } else {
+        console.log("Adding new dish to database");
+        await setDoc(dishRef, newDish);  
+    }
+
+};
+
+export const fetchAllDishes = async () => {
+    const collectionRef = collection(db, "dishes");
+    const snapshot = await getDocs(collectionRef);
+    let dishes = <dishItem[]> [];
+    snapshot.forEach(doc => {
+        dishes.push(<dishItem> doc.data());
+    });
+    return dishes;
+}

--- a/triton-eats/server/src/Menu/menu-endpoints.ts
+++ b/triton-eats/server/src/Menu/menu-endpoints.ts
@@ -1,7 +1,9 @@
-import { fetchMenuItems, fetchAllMenuItems } from "./menu-utils";
+import { fetchAllDishes } from "./menu-database";
 import { DiningHalls } from "./types";
 
 export async function createDishEndpoints(app: any) {
+
+    let items = await fetchAllDishes();
     
     app.get('/dishes/:diningHall', async (req: any, res: any) => {
         const diningHall = req.params.diningHall;
@@ -9,11 +11,11 @@ export async function createDishEndpoints(app: any) {
             res.status(400).send('Invalid dining hall');
             return;
         }
-        res.send(await fetchMenuItems(diningHall));
+        res.send(items.filter((item) => item.location.dining_hall === diningHall));
     });
 
     app.get('/dishes', async (req: any, res: any) => {
-        res.send(await fetchAllMenuItems());
+        res.send(items);
     });
 
 }

--- a/triton-eats/server/src/Menu/menu-utils.ts
+++ b/triton-eats/server/src/Menu/menu-utils.ts
@@ -2,6 +2,7 @@ import * as cheerio from 'cheerio';
 
 import { DiningHalls, dishItem, location } from './types';
 import { HDHEndpoints } from './constants';
+import { findDish, updateDishDB, addDishToDB } from './menu-database';
 
 function parseMenuItems(diningHall: DiningHalls, dom: cheerio.Root, restaurantElement: cheerio.Cheerio) {
 
@@ -30,7 +31,7 @@ function parseMenuItems(diningHall: DiningHalls, dom: cheerio.Root, restaurantEl
 function mockDishItem(food_name: string, cost: number, description: string, diningHall: DiningHalls, restaurant: string) {
     
     const location = <location> { name: restaurant, dining_hall: diningHall, location_id: 0 };
-    return <dishItem> { food_id: 0, img: '/images/placeHolderImage.png', food_name, cost, location, allergens: [], rating: 5, description, numReviews: 0, numRecommend: 0 };
+    return <dishItem> { food_id: "0", img: '/images/placeHolderImage.png', food_name, cost, location, allergens: [], rating: 5, description, numReviews: 0, numRecommend: 0 };
 
 }
 
@@ -78,4 +79,13 @@ export async function fetchAllMenuItems() {
     }
 
     return items;
+}
+
+export async function populateDatabase() {
+    const dishes = await fetchAllMenuItems();
+
+    for(const dish of dishes) {
+        await addDishToDB(dish);
+    }
+
 }

--- a/triton-eats/server/src/Menu/types.ts
+++ b/triton-eats/server/src/Menu/types.ts
@@ -1,6 +1,6 @@
 
 export type dishItem = {
-    food_id: number;
+    food_id: string;
     img: string;
     food_name: string;
     cost: number;
@@ -30,3 +30,17 @@ export interface location {
     location_id: number;
 }
 
+
+export interface Review {
+    datetime: Date;
+    food_id: string;
+    img: string;
+    food_name: string;
+    cost: number;
+    location: location;
+    rating: number;
+    review_text: string;
+    recommend: boolean;
+
+    //reviewer_id: number; ---> When we include user accounts, add this to track who reviews what
+}

--- a/triton-eats/server/src/firebaseConfig.ts
+++ b/triton-eats/server/src/firebaseConfig.ts
@@ -1,0 +1,28 @@
+import { initializeApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
+import dotenv from 'dotenv';
+
+dotenv.config({ path: './.env' }); 
+
+
+const firebaseConfig = {
+
+  apiKey: "AIzaSyAeum9QrymFNfs8SCCXRygLXYo_Vd2ZS_Y",
+
+  authDomain: "tritoneats-ce4d9.firebaseapp.com",
+
+  projectId: "tritoneats-ce4d9",
+
+  storageBucket: "tritoneats-ce4d9.firebasestorage.app",
+
+  messagingSenderId: "534166052068",
+
+  appId: "1:534166052068:web:9bc417bd54a98971ec20f1"
+
+};
+
+
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);
+console.log("Firebase app initialized:", app.name);

--- a/triton-eats/server/src/menu/menu-endpoints.ts
+++ b/triton-eats/server/src/menu/menu-endpoints.ts
@@ -1,7 +1,9 @@
-import { fetchMenuItems, fetchAllMenuItems } from "./menu-utils";
+import { fetchAllDishes } from "./menu-database";
 import { DiningHalls } from "./types";
 
 export async function createDishEndpoints(app: any) {
+
+    let items = await fetchAllDishes();
     
     app.get('/dishes/:diningHall', async (req: any, res: any) => {
         const diningHall = req.params.diningHall;
@@ -9,11 +11,11 @@ export async function createDishEndpoints(app: any) {
             res.status(400).send('Invalid dining hall');
             return;
         }
-        res.send(await fetchMenuItems(diningHall));
+        res.send(items.filter((item) => item.location.dining_hall === diningHall));
     });
 
     app.get('/dishes', async (req: any, res: any) => {
-        res.send(await fetchAllMenuItems());
+        res.send(items);
     });
 
 }

--- a/triton-eats/server/src/menu/menu-utils.ts
+++ b/triton-eats/server/src/menu/menu-utils.ts
@@ -2,6 +2,7 @@ import * as cheerio from 'cheerio';
 
 import { DiningHalls, dishItem, location } from './types';
 import { HDHEndpoints } from './constants';
+import { findDish, updateDishDB, addDishToDB } from './menu-database';
 
 function parseMenuItems(diningHall: DiningHalls, dom: cheerio.Root, restaurantElement: cheerio.Cheerio) {
 
@@ -30,7 +31,7 @@ function parseMenuItems(diningHall: DiningHalls, dom: cheerio.Root, restaurantEl
 function mockDishItem(food_name: string, cost: number, description: string, diningHall: DiningHalls, restaurant: string) {
     
     const location = <location> { name: restaurant, dining_hall: diningHall, location_id: 0 };
-    return <dishItem> { food_id: 0, img: '/images/placeHolderImage.png', food_name, cost, location, allergens: [], rating: 5, description, numReviews: 0, numRecommend: 0 };
+    return <dishItem> { food_id: "0", img: '/images/placeHolderImage.png', food_name, cost, location, allergens: [], rating: 5, description, numReviews: 0, numRecommend: 0 };
 
 }
 
@@ -78,4 +79,13 @@ export async function fetchAllMenuItems() {
     }
 
     return items;
+}
+
+export async function populateDatabase() {
+    const dishes = await fetchAllMenuItems();
+
+    for(const dish of dishes) {
+        await addDishToDB(dish);
+    }
+
 }


### PR DESCRIPTION
Adds functionalities to read and write dishes to Firestore database.

Now dishes endpoints use locally cached version of the menu fetched from DB at startup to speed up response.

On a new branch to fix issues in #44 